### PR TITLE
Restoring the weight back to -10000 for deleted projects

### DIFF
--- a/moduleScore.yaml
+++ b/moduleScore.yaml
@@ -25,7 +25,7 @@ downloads:
 # Is the project source code not publicly available anymore in GitHub
 projectDeleted:
     type: boolean
-    weight: -25
+    weight: -10000
 
 # Is there a README file available on the latest version of the module
 readMeIsAvailable:


### PR DESCRIPTION
Restoring the weight back to -10000 to make sure that popularity score doesn't overpower chaos :)